### PR TITLE
fix: xss vulnerability in creating choice labels

### DIFF
--- a/cypress/integration/text.spec.ts
+++ b/cypress/integration/text.spec.ts
@@ -45,7 +45,7 @@ describe('Choices - text element', () => {
               .should($dropdown => {
                 const dropdownText = $dropdown.text().trim();
                 expect(dropdownText).to.equal(
-                  `Press Enter to add "${textInput}"`,
+                  `Press Enter to add <b>"${textInput}"</b>`,
                 );
               });
           });

--- a/src/scripts/templates.ts
+++ b/src/scripts/templates.ts
@@ -296,7 +296,7 @@ const templates = {
       noResults,
       noChoices,
     }: Pick<ClassNames, 'item' | 'itemChoice' | 'noResults' | 'noChoices'>,
-    innerHTML: string,
+    innerText: string,
     type: 'no-choices' | 'no-results' | '' = '',
   ): HTMLDivElement {
     const classes = [item, itemChoice];
@@ -308,7 +308,7 @@ const templates = {
     }
 
     return Object.assign(document.createElement('div'), {
-      innerHTML,
+      innerText,
       className: classes.join(' '),
     });
   },

--- a/src/scripts/templates.ts
+++ b/src/scripts/templates.ts
@@ -68,7 +68,7 @@ const templates = {
   ): HTMLDivElement {
     return Object.assign(document.createElement('div'), {
       className: placeholder,
-      innerHTML: value,
+      innerText: value,
     });
   },
 
@@ -97,7 +97,7 @@ const templates = {
   ): HTMLDivElement {
     const div = Object.assign(document.createElement('div'), {
       className: item,
-      innerHTML: label,
+      innerText: label,
     });
 
     Object.assign(div.dataset, {
@@ -131,7 +131,7 @@ const templates = {
       const removeButton = Object.assign(document.createElement('button'), {
         type: 'button',
         className: button,
-        innerHTML: REMOVE_ITEM_TEXT,
+        innerText: REMOVE_ITEM_TEXT,
       });
       removeButton.setAttribute(
         'aria-label',
@@ -187,7 +187,7 @@ const templates = {
     div.appendChild(
       Object.assign(document.createElement('div'), {
         className: groupHeading,
-        innerHTML: value,
+        innerText: value,
       }),
     );
 
@@ -225,7 +225,7 @@ const templates = {
   ): HTMLDivElement {
     const div = Object.assign(document.createElement('div'), {
       id: elementId,
-      innerHTML: label,
+      innerText: label,
       className: `${item} ${itemChoice}`,
     });
 


### PR DESCRIPTION
## Description

This addresses a XSS vulnerability when creating labels for choices. For example, if we set the label property of a choice to the HTML string `<img src=x onerror=alert()>` like so:
```
var singleNoSearch = new Choices('#choices-single-no-search', {
          searchEnabled: false,
          removeItemButton: true,
          choices: [
            { value: 'One', label: '<img src=x onerror=alert()>' },
            { value: 'Two', label: 'Label Two', disabled: true },
            { value: 'Three', label: 'Label Three' },
          ],
        });
```
It will execute the JavaScript function defined in the `onerror` attribute since the `src` does not exist. An attacker can exploit this.

The issue was that when creating the choice / placeholder elements, it would set the `innerHTML` content of the element. Instead, since these are just string labels, we should be setting the content as a string using the `innerText` property.

## Screenshots (if appropriate)
Choices executing JavaScript functions (`alert()`) defined in a label string.
![choices-js-xss](https://user-images.githubusercontent.com/57642662/134376328-118a7a11-3b3a-4230-96e5-9b0a9680e65a.png)